### PR TITLE
Use Prematch game phase to shuffle teams

### DIFF
--- a/mod/scripts/vscripts/team_shuffle_auto.nut
+++ b/mod/scripts/vscripts/team_shuffle_auto.nut
@@ -6,7 +6,7 @@ array<string> disabledModes = ["private_match", "inf", "hs", "ffa", "gg"]
 void function AutoShuffleTeamsHook()
 {
     // Shuffle teams at the end of the match
-	AddCallback_GameStateEnter(eGameState.Postmatch, AutoShuffleTeams)
+	AddCallback_GameStateEnter(eGameState.Prematch, AutoShuffleTeams)
 }
 
 void function AutoShuffleTeams()


### PR DESCRIPTION
Switch to shuffling teams at the Prematch game phase. This will no longer cause people to swap on the end screen with scoreboard no longer reflecting true end results. 